### PR TITLE
Fix undeclared variables use

### DIFF
--- a/common.php
+++ b/common.php
@@ -147,7 +147,7 @@ function get_readings_rbee($start, $end, $second)
     // Trigger the query
     $select_messages = $db->prepare($qr);
     $select_messages->setFetchMode(PDO::FETCH_ASSOC);
-    $select_messages->execute($reqArgs);
+    $select_messages->execute();
 
     // Send the content
     return $select_messages->fetchAll();
@@ -260,7 +260,7 @@ function get_readings_ticpmepmi($start, $end, $second)
     // Trigger the query
     $select_messages = $db->prepare($qr);
     $select_messages->setFetchMode(PDO::FETCH_ASSOC);
-    $select_messages->execute($reqArgs);
+    $select_messages->execute();
     $readings = $select_messages->fetchAll();
 
     $result = [];

--- a/get10mn.php
+++ b/get10mn.php
@@ -43,9 +43,6 @@ elseif (strcmp($_GET['family'],"tic")==0){
 elseif (strcmp($_GET['family'],"ticpmepmi")==0){
   $reqArgs=array($_GET['serial']);
 
-  $start = $start-$offset;
-  $end = $end-$offset;
-
   // Round start/end to tens minutes in order to match
   // DB when generating missing ts
   $start = 600 * ceil($start / 600);


### PR DESCRIPTION
I guess that I use a newer PHP version than you, which is less permissive about undeclared var