### PR TITLE
Fix compression

### DIFF
--- a/get10mn.php
+++ b/get10mn.php
@@ -3,8 +3,8 @@ require_once "constants.php";
 require_once "ids.php"; // Contains the identifier + Password to connect to RTone web API
 require_once "common.php"; 
 
-ini_set("zlib.output_compression", "On");
-ini_set("zlib.output_compression_level", "-1");
+// ini_set("zlib.output_compression", "On");
+// ini_set("zlib.output_compression_level", "-1");
 
 $db = connect_to_db();
 

--- a/get1h.php
+++ b/get1h.php
@@ -3,9 +3,6 @@ require_once "constants.php";
 require_once "ids.php"; // Contains the identifier + Password to connect to RTone web API
 require_once "common.php";
 
-ini_set("zlib.output_compression", "On");
-ini_set("zlib.output_compression_level", "-1");
-
 $db = connect_to_db();
 
 // $_GET should contain serial, start, end 


### PR DESCRIPTION
Compression is already handled by the server if the browser is compatible, screenshot made with this PR applied:

![image](https://user-images.githubusercontent.com/62252731/214099541-a598d5a5-552e-4455-8a2b-3f16df9b55f8.png)

I guess that OVH was not applying any compression to save VPS CPU load...